### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: CI Meson
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: ["master", "dev"]


### PR DESCRIPTION
Potential fix for [https://github.com/CryptixOS/CryptixOS/security/code-scanning/2](https://github.com/CryptixOS/CryptixOS/security/code-scanning/2)

To fix the issue, an explicit `permissions` block will be added to the root of the workflow. Based on the steps in the workflow, it primarily performs code checkouts and builds, which suggests it only needs read access to repository contents. Therefore, the `permissions` block will set `contents: read`. If further permissions are required in the future, they can be added explicitly.

Changes needed:
1. Add a `permissions` block at the top level of the workflow to restrict the default permissions.
2. Ensure that `contents: read` is the only permission granted unless additional permissions are required for specific tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
